### PR TITLE
Fixing comparison of cuda matrix

### DIFF
--- a/gpu.py
+++ b/gpu.py
@@ -231,7 +231,7 @@ class TempGPUMem(dict):
                              shape,
                              key)
                 self[key] = cm.empty(shape)
-            elif self[key] != shape:
+            elif self[key].shape != shape:
                 logger.debug('%s: reshaped %s from %s to %s',
                              sys._getframe().f_code.co_name,
                              key,


### PR DESCRIPTION
Inside TempGPUMem class there is a comparison in alloc() that
check whether the current shape of self[key] has changed. However,
the comparison is missing a shape attribute in self[key], since it
is a cuda matrix object.

Such problem yields GPU memory allocation issues that in some
scenarios makes the program use much more GPU memory (twice sometimes).