### PR TITLE
Convert to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Python module to train GMMs using CUDA (via CUDAMat)
 * CUDA 6.0+ (only tested with 6.0)
 * numpy
 * CUDAMat, avaiable here: https://github.com/cudamat/cudamat.git
+* future: http://python-future.org/index.html
 * nose (optional, for running tests)
 
 ### Installation

--- a/ggmm/cpu.py
+++ b/ggmm/cpu.py
@@ -5,6 +5,10 @@ CPU/Numpy backend for GMM training and inference
 # Author: Eric Battenberg <ebattenberg@gmail.com>
 # Based on gmm.py from sklearn
 
+# python2 compatibility
+from __future__ import print_function
+from builtins import range
+
 import numbers
 import numpy as np
 from scipy import linalg
@@ -302,8 +306,8 @@ class GMM(object):
         if np.any(self.covars < self.min_covar):
             self.covars[self.covars < self.min_covar] = self.min_covar
             if self.verbose:
-                print 'input covars less than min_covar (%g) ' \
-                    'have been set to %g' % (self.min_covar, self.min_covar)
+                print('input covars less than min_covar (%g) ' \
+                    'have been set to %g' % (self.min_covar, self.min_covar))
 
     def get_weights(self):
         '''
@@ -446,7 +450,7 @@ class GMM(object):
         # decide which component to use for each sample
         comps = weight_cdf.searchsorted(rand)
         # for each component, generate all needed samples
-        for comp in xrange(self.n_components):
+        for comp in range(self.n_components):
             # occurrences of current component in X
             comp_in_X = (comp == comps)
             # number of those occurrences
@@ -528,7 +532,7 @@ class GMM(object):
 
         max_log_prob = -np.infty
 
-        for _ in xrange(n_init):
+        for _ in range(n_init):
             if 'm' in init_params or self.means is None:
                 perm = random_state.permutation(n_samples)
                 self.means = X[perm[:self.n_components]].copy()
@@ -548,14 +552,14 @@ class GMM(object):
             # EM algorithms
             log_likelihood = []
             converged = False
-            for i in xrange(n_iter):
+            for i in range(n_iter):
                 # Expectation step
                 curr_log_likelihood, responsibilities = self.score_samples(X)
                 curr_log_likelihood_sum = curr_log_likelihood.sum()
                 log_likelihood.append(curr_log_likelihood_sum)
                 if verbose:
-                    print 'Iter: %u, log-likelihood: %f' % (
-                        i, curr_log_likelihood_sum)
+                    print('Iter: %u, log-likelihood: %f' % (
+                        i, curr_log_likelihood_sum))
 
                 # Check for convergence.
                 if i > 0 and abs(log_likelihood[-1] - log_likelihood[-2]) < \
@@ -792,7 +796,7 @@ def _covar_mstep_full(gmm, X, posteriors, weighted_X_sum, norm,
     # Distribution"
     n_dimensions = X.shape[1]
     cv = np.empty((gmm.n_components, n_dimensions, n_dimensions))
-    for c in xrange(gmm.n_components):
+    for c in range(gmm.n_components):
         post = posteriors[:, c]
         # Underflow Errors in doing post * X.T are  not important
         np.seterr(under='ignore')

--- a/ggmm/gpu.py
+++ b/ggmm/gpu.py
@@ -5,6 +5,11 @@ GPU/CUDAMat backend for GMM training and inference
 # Author: Eric Battenberg <ebattenberg@gmail.com>
 # Based on gmm.py from sklearn
 
+# python2 compatibility
+from __future__ import print_function
+from future.utils import iteritems
+from builtins import range
+
 import cudamat as cm
 import logging
 import numbers
@@ -224,7 +229,7 @@ class TempGPUMem(dict):
                 'TempGPUMem: alloc(N, K, D) or alloc(key_shape_mapping)')
 
         # allocate memory
-        for key, shape in key_shape_mapping.iteritems():
+        for key, shape in iteritems(key_shape_mapping):
             if key not in self:
                 logger.debug('%s: created %s at key %s',
                              sys._getframe().f_code.co_name,
@@ -345,8 +350,8 @@ class GMM(object):
         if np.any(covars_ < self.min_covar):
             covars_[covars_ < self.min_covar] = self.min_covar
             if self.verbose:
-                print 'input covars less than min_covar (%g) ' \
-                    'have been set to %g' % (self.min_covar, self.min_covar)
+                print('input covars less than min_covar (%g) ' \
+                    'have been set to %g' % (self.min_covar, self.min_covar))
 
         self.covars = return_CUDAMatrix(covars_)
 
@@ -572,7 +577,7 @@ class GMM(object):
 
         max_log_prob = -np.infty
 
-        for _ in xrange(n_init):
+        for _ in range(n_init):
             if 'm' in init_params or self.means is None:
                 perm = random_state.permutation(n_samples)
                 self.means = return_CUDAMatrix(X[perm[:self.n_components]])
@@ -593,7 +598,7 @@ class GMM(object):
             # EM algorithms
             log_likelihood = []
             converged = False
-            for i in xrange(n_iter):
+            for i in range(n_iter):
                 # Expectation step
                 curr_log_likelihood, posteriors = self.score_samples(
                     X_gpu, temp_gpu_mem)
@@ -605,9 +610,9 @@ class GMM(object):
                 else:
                     change = np.inf
                 if verbose:
-                    print 'Iter: %u, log-likelihood: %g ' \
+                    print('Iter: %u, log-likelihood: %g ' \
                         '(change = %g)' % (
-                            i, curr_log_likelihood_sum, change)
+                            i, curr_log_likelihood_sum, change))
 
                 # Check for convergence.
                 if change < thresh:

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,10 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering'
     ],
     keywords='GMM CUDA',
     packages=find_packages(exclude=['tests']),
-    install_requires=['CUDAMat'],
-    python_requires='==2.*'
+    install_requires=['CUDAMat', 'future']
 )

--- a/tests/test_ggmm.py
+++ b/tests/test_ggmm.py
@@ -1,3 +1,7 @@
+# python2 compatibility
+from __future__ import print_function
+from builtins import range
+
 import logging
 import time
 import os
@@ -242,7 +246,7 @@ def check_time_score_samples(N,K,D):
     X_gpu = ggmm.return_CUDAMatrix(X)
     gpu_trials = 0
     t0 = time.time()
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         logprob_gpu, posterior_gpu = gmm_gpu.score_samples(X_gpu,temp_gpu_mem)
         gpu_time = time.time() - t0
         gpu_trials += 1
@@ -252,7 +256,7 @@ def check_time_score_samples(N,K,D):
 
     t0 = time.time()
     cpu_trials = 0
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         logprob_cpu, posterior_cpu = gmm_cpu.score_samples(X)
         cpu_time = time.time() - t0
         cpu_trials += 1
@@ -262,14 +266,14 @@ def check_time_score_samples(N,K,D):
 
     speedup = avg_cpu_time/avg_gpu_time
 
-    print ''
-    print '------------------------------------'
-    print 'N=%u, K=%u, D=%u' % (N,K,D)
-    print 'avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time
-    print 'avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time
-    print 'speedup:', speedup
-    print '------------------------------------'
-    print ''
+    print('')
+    print('------------------------------------')
+    print('N=%u, K=%u, D=%u' % (N,K,D))
+    print('avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time)
+    print('avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time)
+    print('speedup:', speedup)
+    print('------------------------------------')
+    print('')
     assert_greater(speedup, 1.0)
 
 # ------------------------------------------
@@ -353,7 +357,7 @@ def check_time_do_mstep(N,K,D):
 
     gpu_trials = 0
     t0 = time.time()
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         gmm_gpu._do_mstep(X_gpu,posterior_gpu, update_params, min_covar)
         gpu_time = time.time() - t0
         gpu_trials += 1
@@ -363,7 +367,7 @@ def check_time_do_mstep(N,K,D):
 
     t0 = time.time()
     cpu_trials = 0
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         gmm_cpu._do_mstep(X,posterior_cpu, update_params, min_covar)
         cpu_time = time.time() - t0
         cpu_trials += 1
@@ -373,14 +377,14 @@ def check_time_do_mstep(N,K,D):
 
     speedup = avg_cpu_time/avg_gpu_time
 
-    print ''
-    print '------------------------------------'
-    print 'N=%u, K=%u, D=%u' % (N,K,D)
-    print 'avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time
-    print 'avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time
-    print 'speedup:', speedup
-    print '------------------------------------'
-    print ''
+    print('')
+    print('------------------------------------')
+    print('N=%u, K=%u, D=%u' % (N,K,D))
+    print('avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time)
+    print('avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time)
+    print('speedup:', speedup)
+    print('------------------------------------')
+    print('')
     assert_greater(speedup, 1.0)
 
 # ------------------------------------------
@@ -452,7 +456,7 @@ def check_time_fit(N,K,D):
 
     gpu_trials = 0
     t0 = time.time()
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         gmm_gpu.fit(X, thresh, n_iter, init_params=init_params)
         gpu_time = time.time() - t0
         gpu_trials += 1
@@ -462,7 +466,7 @@ def check_time_fit(N,K,D):
 
     t0 = time.time()
     cpu_trials = 0
-    for i in xrange(MAX_TRIALS):
+    for i in range(MAX_TRIALS):
         gmm_cpu.fit(X, thresh, n_iter, init_params=init_params)
         cpu_time = time.time() - t0
         cpu_trials += 1
@@ -472,14 +476,14 @@ def check_time_fit(N,K,D):
 
     speedup = avg_cpu_time/avg_gpu_time
 
-    print ''
-    print '------------------------------------'
-    print 'N=%u, K=%u, D=%u' % (N,K,D)
-    print 'avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time
-    print 'avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time
-    print 'speedup:', speedup
-    print '------------------------------------'
-    print ''
+    print('')
+    print('------------------------------------')
+    print('N=%u, K=%u, D=%u' % (N,K,D))
+    print('avg_cpu_time (%u trials):' % cpu_trials, avg_cpu_time)
+    print('avg_gpu_time (%u trials):' % gpu_trials, avg_gpu_time)
+    print('speedup:', speedup)
+    print('------------------------------------')
+    print('')
     assert_greater(speedup, 1.0)
 
 def test_correct_fit():


### PR DESCRIPTION
Also preserve python2 compatibility via python-future.

To drop py2 support, just remove the relevant import section and `future` dependency.